### PR TITLE
fix check in removeUnwantedModuleMetaboxes.

### DIFF
--- a/source/php/App.php
+++ b/source/php/App.php
@@ -20,7 +20,7 @@ class App
     public function removeUnwantedModuleMetaboxes($postType)
     {
         $allowedPostTypes = apply_filters('CustomerFeedback/post_types', get_field('customer_feedback_posttypes', 'option'));
-        if (is_null($allowedPostTypes)) {
+        if (!is_array($allowedPostTypes)) {
             $allowedPostTypes = array('page');
         }
 


### PR DESCRIPTION
it failed if $allowedPostTypes = "".


encountered this  when trying to add a new field group in acf.
`/post-new.php?post_type=acf-field-group`

it would call like this:

```php
    public function removeUnwantedModuleMetaboxes($postType)
    {
        // $postType = "acf-field-group"
        $allowedPostTypes = apply_filters('CustomerFeedback/post_types', get_field('customer_feedback_posttypes', 'option'));
        // $allowedPostTypes = ""
        // check skipped as it's not null
        if (is_null($allowedPostTypes)) {
            $allowedPostTypes = array('page');
        }
       // calling: in_array("acf-field-group", "")
       // exception thrown: TypeError: in_array(): Argument #2 ($haystack) must be of type array, string given      
        if (!in_array($postType, $allowedPostTypes)) {
            remove_meta_box('acf-group_591c10ab88d77', $postType, 'side');
        }
    }
```